### PR TITLE
Remove override of createJSModules (RN 0.47 compatibility)

### DIFF
--- a/android/src/main/java/io/rumors/reactnativesettings/RNSettingsPackage.java
+++ b/android/src/main/java/io/rumors/reactnativesettings/RNSettingsPackage.java
@@ -16,7 +16,6 @@ public class RNSettingsPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNSettingsModule(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
The current release for React Native 0.47 has removed the createJSModules method in ReactPackage. Therefore any overrides of this method will need to be removed from the library, or this will cause a compilation error.

See: facebook/react-native@ce6fb33

Commit ripped from https://github.com/oblador/react-native-vector-icons/pull/516

Closes #3 