### PR TITLE
Changed invalid import

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ add the following:
 #### Android
 
 1. Open up `android/app/src/main/java/[...]/MainActivity.java`
-  - Add `import com.reactlibrary.RNSettingsPackage;` to the imports at the top of the file
+  - Add `import io.rumors.reactnativesettings.RNSettingsPackage;` to the imports at the top of the file
   - Add `new RNSettingsPackage()` to the list returned by the `getPackages()` method
 2. Append the following lines to `android/settings.gradle`:
   	```


### PR DESCRIPTION
On Android manual installation, I used import com.reactlibrary.RNSettingsPackage which does not exist. After research, I found import io.rumors.reactnativesettings.RNSettingsPackage which works.