### PR TITLE
Fix android gradle minSdkVersion for react-native 0.64 #83

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ android {
     buildToolsVersion projectVar('buildToolsVersion', '23.0.1')
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion projectVar('minSdkVersion', 16)
         targetSdkVersion projectVar('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Fix android build fails for AndroidTest with minSdkVersion 17 with react-native 0.64 ( #83)