### PR TITLE
build: remove jcenter, add google

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,7 @@
 buildscript {
+    repositories {
+        google()
+    }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.1'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,9 +1,4 @@
-
 buildscript {
-    repositories {
-        jcenter()
-    }
-
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.1'
     }


### PR DESCRIPTION
This is because of the recent shutdown (or large blackout period) of jcenter. I don't see any published dependencies to Maven for this, so this appears safe.