### PR TITLE
Android enhancements + build fix.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,20 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - name: Use Node.js 12
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
         with:
-          node-version: 12.x
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: update yarn to latest version
-        run: |
-          sudo apt update && sudo apt install yarn
+          node-version: 16.x
+          cache: 'yarn'
       - name: yarn install and publish
         run: |
           node --version

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,9 +1,12 @@
 buildscript {
-    repositories {
-        google()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+    // Only obtain Build Tools when building in isolation.
+    if (project == rootProject) {
+        repositories {
+            google()
+        }
+        dependencies {
+            classpath 'com.android.tools.build:gradle:1.3.1'
+        }
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ android {
     buildToolsVersion projectVar('buildToolsVersion', '23.0.1')
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion projectVar('minSdkVersion', 16)
         targetSdkVersion projectVar('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
* Added an optimization to not download build tools unless root project (helps when just using package in RN)
* Allowed `minSdKVersion` to be overridden during build.
* Upgraded all actions to v3 equivalent, as well as retiring cache for build in `setup-node` cache.


---
* Tested via building /example and ensuring all worked. 