### PR TITLE
fix: add mavenCentral for repositories

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         google()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.1'


### PR DESCRIPTION
After moving to v1.0.1 - we still had issues. Trying to upstream all fixes we had collected over the years.

```
Could not find com.android.tools.build:gradle:1.3.1.
Searched in the following locations:
  - https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/1.3.1/gradle-1.3.1.pom
Required by:
    project :react-native-settings
```

Some packages (in this case gradle) are not in Google's Maven, but Maven Central.

fixes: #131 