### PR TITLE
fix: allow overriding minSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
     buildToolsVersion projectVar('buildToolsVersion', '23.0.1')
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion projectVar('minSdkVersion', 16)
         targetSdkVersion projectVar('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Fixes this issue from a hard-coded minSdk poisioning gradle values.

```
uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library...
```

fixes: #83 